### PR TITLE
Fix Installed-size field in Packages

### DIFF
--- a/lib/deb/s3/package.rb
+++ b/lib/deb/s3/package.rb
@@ -239,6 +239,7 @@ class Deb::S3::Package
     self.url = parse.call("Homepage")
     self.vendor = parse.call("Vendor") || self.vendor
     self.attributes[:deb_priority] = parse.call("Priority")
+    self.attributes[:deb_installed_size] = parse.call("Installed-Size")
 
     # Packages manifest fields
     self.url_filename = parse.call("Filename")


### PR DESCRIPTION
Don't leave Installed-Size field empty, otherwise apt-get will upgrade the package every time it's run.
