### PR TITLE
added component path to s3 upload for packages to match Ubuntu standards

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -225,6 +225,7 @@ class Deb::S3::CLI < Thor
     Deb::S3::Utils.bucket      = options[:bucket]
     Deb::S3::Utils.signing_key = options[:sign]
     Deb::S3::Utils.gpg_options = options[:gpg_options]
+    Deb::S3::Utils.component   = options[:component]
 
     # make sure we have a valid visibility setting
     Deb::S3::Utils.access_policy = case options[:visibility]

--- a/lib/deb/s3/package.rb
+++ b/lib/deb/s3/package.rb
@@ -118,11 +118,11 @@ class Deb::S3::Package
   end
 
   def url_filename
-    @url_filename || "pool/#{self.name[0]}/#{self.name[0..1]}/#{File.basename(self.filename)}"
+    @url_filename || "pool/#{Deb::S3::Utils.component}/#{self.name[0]}/#{self.name[0..1]}/#{File.basename(self.filename)}"
   end
 
   def url_filename_encoded
-    @url_filename || "pool/#{self.name[0]}/#{self.name[0..1]}/#{s3_escape(File.basename(self.filename))}"
+    @url_filename || "pool/#{Deb::S3::Utils.component}/#{self.name[0]}/#{self.name[0..1]}/#{s3_escape(File.basename(self.filename))}"
   end
 
   def needs_uploading?

--- a/lib/deb/s3/utils.rb
+++ b/lib/deb/s3/utils.rb
@@ -11,6 +11,8 @@ module Deb::S3::Utils
   def signing_key= v; @signing_key = v end
   def gpg_options; @gpg_options end
   def gpg_options= v; @gpg_options = v end
+  def component; @component end
+  def component= v; @component = v end
 
   def safesystem(*args)
     success = system(*args)


### PR DESCRIPTION
We needed this internally to match the Ubuntu standard of pool/$component/$first letter/$first two letters/$package, and to separate out files by component.
