### PR TITLE
Add path prefix option for S3 storage.

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -16,6 +16,10 @@ class Deb::S3::CLI < Thor
   :aliases  => "-b",
   :desc     => "The name of the S3 bucket to upload to."
 
+  class_option :prefix,
+  :type     => :string,
+  :desc     => "The path prefix to use when storing on S3."
+
   class_option :codename,
   :default  => "stable",
   :type     => :string,
@@ -212,6 +216,7 @@ class Deb::S3::CLI < Thor
     Deb::S3::Utils.bucket      = options[:bucket]
     Deb::S3::Utils.signing_key = options[:sign]
     Deb::S3::Utils.gpg_options = options[:gpg_options]
+    Deb::S3::Utils.prefix      = options[:prefix]
 
     # make sure we have a valid visibility setting
     Deb::S3::Utils.access_policy =

--- a/lib/deb/s3/utils.rb
+++ b/lib/deb/s3/utils.rb
@@ -13,6 +13,8 @@ module Deb::S3::Utils
   def signing_key= v; @signing_key = v end
   def gpg_options; @gpg_options end
   def gpg_options= v; @gpg_options = v end
+  def prefix; @prefix end
+  def prefix= v; @prefix = v end
 
   def safesystem(*args)
     success = system(*args)
@@ -34,6 +36,10 @@ module Deb::S3::Utils
     ERB.new(template_code, nil, "-")
   end
 
+  def s3_path(path)
+    File.join(*[Deb::S3::Utils.prefix, path].compact)
+  end
+
   # from fog, Fog::AWS.escape
   def s3_escape(string)
     string.gsub(/([^a-zA-Z0-9_.\-~]+)/) {
@@ -42,24 +48,24 @@ module Deb::S3::Utils
   end
 
   def s3_exists?(path)
-    Deb::S3::Utils.s3.buckets[Deb::S3::Utils.bucket].objects[path].exists?
+    Deb::S3::Utils.s3.buckets[Deb::S3::Utils.bucket].objects[s3_path(path)].exists?
   end
 
   def s3_read(path)
     return nil unless s3_exists?(path)
-    Deb::S3::Utils.s3.buckets[Deb::S3::Utils.bucket].objects[path].read
+    Deb::S3::Utils.s3.buckets[Deb::S3::Utils.bucket].objects[s3_path(path)].read
   end
 
   def s3_store(path, filename=nil)
     filename = File.basename(path) unless filename
     File.open(path) do |file|
-      o = Deb::S3::Utils.s3.buckets[Deb::S3::Utils.bucket].objects[filename]
+      o = Deb::S3::Utils.s3.buckets[Deb::S3::Utils.bucket].objects[s3_path(filename)]
       o.write(file)
       o.acl = Deb::S3::Utils.access_policy
     end
   end
 
   def s3_remove(path)
-    Deb::S3::Utils.s3.buckets[Deb::S3::Utils.bucket].objects[path].delete if s3_exists?(path)
+    Deb::S3::Utils.s3.buckets[Deb::S3::Utils.bucket].objects[s3_path(path)].delete if s3_exists?(path)
   end
 end


### PR DESCRIPTION
By default, uploaded files are stored at the root of the S3 bucket. This change allows to specify an optional path prefix.
