### PR TITLE
The filename passed to S3 should not be url encoded.

### DIFF
--- a/lib/deb/s3/manifest.rb
+++ b/lib/deb/s3/manifest.rb
@@ -82,7 +82,7 @@ class Deb::S3::Manifest
     @packages.each do |pkg|
       if pkg.needs_uploading?
         yield pkg.url_filename if block_given?
-        s3_store(pkg.filename, pkg.url_filename_encoded)
+        s3_store(pkg.filename, pkg.url_filename)
       end
     end
 


### PR DESCRIPTION
Found this while attempting to add a .deb with an embedded %.
The addition to the private repo succeeded, but running apt-get install of the package failed because the file in the pool had the % url encoded.
