### PR TITLE
Add Content-Type to S3 objects

### DIFF
--- a/lib/deb/s3/manifest.rb
+++ b/lib/deb/s3/manifest.rb
@@ -82,7 +82,7 @@ class Deb::S3::Manifest
     @packages.each do |pkg|
       if pkg.needs_uploading?
         yield pkg.url_filename if block_given?
-        s3_store(pkg.filename, pkg.url_filename)
+        s3_store(pkg.filename, pkg.url_filename, 'application/octet-stream; charset=binary')
       end
     end
 
@@ -92,7 +92,7 @@ class Deb::S3::Manifest
     pkgs_temp.close
     f = "dists/#{@codename}/#{@component}/binary-#{@architecture}/Packages"
     yield f if block_given?
-    s3_store(pkgs_temp.path, f)
+    s3_store(pkgs_temp.path, f, 'text/plain; charset=us-ascii')
     @files["#{@component}/binary-#{@architecture}/Packages"] = hashfile(pkgs_temp.path)
     pkgs_temp.unlink
 
@@ -102,7 +102,7 @@ class Deb::S3::Manifest
     Zlib::GzipWriter.open(gztemp.path) { |gz| gz.write manifest }
     f = "dists/#{@codename}/#{@component}/binary-#{@architecture}/Packages.gz"
     yield f if block_given?
-    s3_store(gztemp.path, f)
+    s3_store(gztemp.path, f, 'application/x-gzip; charset=binary')
     @files["#{@component}/binary-#{@architecture}/Packages.gz"] = hashfile(gztemp.path)
     gztemp.unlink
 

--- a/lib/deb/s3/release.rb
+++ b/lib/deb/s3/release.rb
@@ -86,7 +86,7 @@ class Deb::S3::Release
     release_tmp.puts self.generate
     release_tmp.close
     yield self.filename if block_given?
-    s3_store(release_tmp.path, self.filename)
+    s3_store(release_tmp.path, self.filename, 'text/plain; charset=us-ascii')
 
     # sign the file, if necessary
     if Deb::S3::Utils.signing_key
@@ -96,7 +96,7 @@ class Deb::S3::Release
         remote_file = self.filename+".gpg"
         yield remote_file if block_given?
         raise "Unable to locate Release signature file" unless File.exists?(local_file)
-        s3_store(local_file, remote_file)
+        s3_store(local_file, remote_file, 'application/pgp-signature; charset=us-ascii')
         File.unlink(local_file)
       else
         raise "Signing the Release file failed."

--- a/lib/deb/s3/utils.rb
+++ b/lib/deb/s3/utils.rb
@@ -58,7 +58,7 @@ module Deb::S3::Utils
     Deb::S3::Utils.s3.buckets[Deb::S3::Utils.bucket].objects[s3_path(path)].read
   end
 
-  def s3_store(path, filename=nil)
+  def s3_store(path, filename=nil, content_type='application/octet-stream; charset=binary')
     filename = File.basename(path) unless filename
     obj = Deb::S3::Utils.s3.buckets[Deb::S3::Utils.bucket].objects[s3_path(filename)]
 
@@ -69,7 +69,7 @@ module Deb::S3::Utils
     end
 
     # upload the file
-    obj.write(Pathname.new(path), :acl => Deb::S3::Utils.access_policy)
+    obj.write(Pathname.new(path), :acl => Deb::S3::Utils.access_policy, :content_type => content_type)
   end
 
   def s3_remove(path)


### PR DESCRIPTION
Ran into issues on precise 12.04.2 where `apt-get` would report `Bad header line` on my S3 repository. Tracked it down to missing `Content-Type` on the files in the bucket. S3 reported malformed `Content-Type:`.
