### PR TITLE
Add support for `proxy_uri` and `use_ssl`

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -50,6 +50,15 @@ class Deb::S3::CLI < Thor
   :desc     => "The region endpoint for connecting to S3.",
   :default  => "s3.amazonaws.com"
 
+  class_option :proxy_uri,
+  :type     => :string,
+  :desc     => "The URI of the proxy to send service requests through."
+
+  class_option :use_ssl,
+  :default  => true,
+  :type     => :boolean,
+  :desc     => "Whether to use HTTP or HTTPS for request transport."
+
   class_option :visibility,
   :default  => "public",
   :type     => :string,
@@ -286,7 +295,11 @@ class Deb::S3::CLI < Thor
   def configure_s3_client
     error("No value provided for required options '--bucket'") unless options[:bucket]
 
-    settings = { :s3_endpoint => options[:endpoint] }
+    settings = {
+      :s3_endpoint => options[:endpoint],
+      :proxy_uri   => options[:proxy_uri],
+      :use_ssl     => options[:use_ssl]
+    }
     settings.merge!(provider.credentials)
 
     Deb::S3::Utils.s3          = AWS::S3.new(settings)


### PR DESCRIPTION
Most private object storage solutions support direct and proxy configurations. For clients interacting with object stores in a direct configuration, overriding `endpoint` works. In order to support object stores in a proxy configuration, this commit adds a `proxy_uri` option (along with a `use_ssl` flag for object stores without HTTPS enabled).

Example usage:

``` bash
$ deb-s3 upload --access-key-id "Y6W_BQNKFAS9XMN43-GJ" --secret-access-key "S8PQ6lSQ8q6GIauyQ3g2yozJRST3RpagymBkVg==" \
    --proxy-uri "http://localhost:8080" --use-ssl=false --bucket joker riak-ee_1.4.8-1_amd64.deb
>> Retrieving existing manifests
>> Examining package file riak-ee_1.4.8-1_amd64.deb
>> Uploading packages and new manifests to S3
   -- Transferring pool/r/ri/riak-ee_1.4.8-1_amd64.deb
   -- Transferring dists/stable/main/binary-amd64/Packages
   -- Transferring dists/stable/main/binary-amd64/Packages.gz
   -- Transferring dists/stable/Release
>> Update complete.
$ deb-s3 verify --access-key-id "Y6W_BQNKFAS9XMN43-GJ" --secret-access-key "S8PQ6lSQ8q6GIauyQ3g2yozJRST3RpagymBkVg==" \
    --proxy-uri "http://localhost:8080" --use-ssl=false --bucket joker
>> Retrieving existing manifests
>> Checking for missing packages in: stable/main amd64
>> Checking for missing packages in: stable/main armel
>> Checking for missing packages in: stable/main i386
>> Checking for missing packages in: stable/main all
```

(This test was done against a local instance of Riak CS with the S3 API enabled.)
