### PR TITLE
Fixes #37: Stores checksum in metadata

### DIFF
--- a/lib/deb/s3/utils.rb
+++ b/lib/deb/s3/utils.rb
@@ -64,14 +64,15 @@ module Deb::S3::Utils
     filename = File.basename(path) unless filename
     obj = Deb::S3::Utils.s3.buckets[Deb::S3::Utils.bucket].objects[s3_path(filename)]
 
+    file_md5 = Digest::MD5.file(path)
+
     # check if the object already exists
     if obj.exists?
-      file_md5 = Digest::MD5.file(path)
-      return if file_md5.to_s == obj.etag.gsub('"', '')
+      return if (file_md5.to_s == obj.etag.gsub('"', '') or file_md5.to_s == obj.metadata['md5'])
     end
 
     # upload the file
-    obj.write(Pathname.new(path), :acl => Deb::S3::Utils.access_policy, :content_type => content_type)
+    obj.write(Pathname.new(path), :acl => Deb::S3::Utils.access_policy, :content_type => content_type, :metadata => {'md5' => file_md5})
   end
 
   def s3_remove(path)


### PR DESCRIPTION
I admit I've not been able to reliably compute the etag generated by AWS - the values returned by scripts I found online, or reproducing the algorithms manually, or writing my own scripts just didn't match the etag from files uploaded by deb-s3.

Even though that might have been practical, the way AWS computes it is still officially "undocumented" and I've seen many people recommending using metadata to store the md5 instead.

Here is a patch that adds a "md5" metadata to the files uploaded by deb-s3 and compares against this (and the etag, for backward compatibility).
