### PR TITLE
deb-s3 verify: force regeneration of manifest and release files if signing key is present

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -250,7 +250,7 @@ class Deb::S3::CLI < Thor
         end
       end
 
-      if options[:fix_manifests] && !missing_packages.empty?
+      if options[:sign] || (options[:fix_manifests] && !missing_packages.empty?)
         log("Removing #{missing_packages.length} package(s) from the manifest...")
         missing_packages.each { |p| manifest.packages.delete(p) }
         manifest.write_to_s3 { |f| sublog("Transferring #{f}") }


### PR DESCRIPTION
This allows to resign the release file after doing a `deb-s3 delete` and forgetting to pass the `--sign` option. Otherwise, we're just stuck until the next upload.
