### PR TITLE
Add option to perform server side encryption

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -77,6 +77,12 @@ class Deb::S3::CLI < Thor
   :type    => :string,
   :desc    => "Additional command line options to pass to GPG when signing"
 
+  class_option :encryption,
+  :default  => false,
+  :type     => :boolean,
+  :aliases  => "-e",
+  :desc     => "Use S3 server side encryption"
+
   desc "upload FILES",
   "Uploads the given files to a S3 bucket as an APT repository."
 
@@ -307,6 +313,7 @@ class Deb::S3::CLI < Thor
     Deb::S3::Utils.signing_key = options[:sign]
     Deb::S3::Utils.gpg_options = options[:gpg_options]
     Deb::S3::Utils.prefix      = options[:prefix]
+    Deb::S3::Utils.encryption  = options[:encryption]
 
     # make sure we have a valid visibility setting
     Deb::S3::Utils.access_policy =

--- a/lib/deb/s3/utils.rb
+++ b/lib/deb/s3/utils.rb
@@ -17,6 +17,8 @@ module Deb::S3::Utils
   def gpg_options= v; @gpg_options = v end
   def prefix; @prefix end
   def prefix= v; @prefix = v end
+  def encryption; @encryption end
+  def encryption= v; @encryption = v end
 
   class SafeSystemError < RuntimeError; end
 
@@ -71,8 +73,12 @@ module Deb::S3::Utils
       return if (file_md5.to_s == obj.etag.gsub('"', '') or file_md5.to_s == obj.metadata['md5'])
     end
 
+    # specify if encryption is required
+    options = {:acl => Deb::S3::Utils.access_policy, :content_type => content_type, :metadata => {'md5' => file_md5}}
+    options[:server_side_encryption] = :aes256 if Deb::S3::Utils.encryption
+
     # upload the file
-    obj.write(Pathname.new(path), :acl => Deb::S3::Utils.access_policy, :content_type => content_type, :metadata => {'md5' => file_md5})
+    obj.write(Pathname.new(path), options)
   end
 
   def s3_remove(path)


### PR DESCRIPTION
This allows someone to specify a `--encryption` of `-e` option to turn storage encryption for the package.

Relies upon Amazon's encryption key generation.
