### PR TITLE
Filenames shouldn't be URL-escaped in the Packages manifest

### DIFF
--- a/lib/deb/s3/package.rb
+++ b/lib/deb/s3/package.rb
@@ -3,6 +3,8 @@ require "digest/sha2"
 require "digest/md5"
 require "socket"
 require "tmpdir"
+require "uri"
+
 require 'deb/s3/utils'
 
 class Deb::S3::Package
@@ -261,7 +263,8 @@ class Deb::S3::Package
     self.attributes[:deb_installed_size] = parse.call("Installed-Size")
 
     # Packages manifest fields
-    self.url_filename = parse.call("Filename")
+    filename = parse.call("Filename")
+    self.url_filename = filename && URI.unescape(filename)
     self.sha1 = parse.call("SHA1")
     self.sha256 = parse.call("SHA256")
     self.md5 = parse.call("MD5sum")

--- a/lib/deb/s3/templates/package.erb
+++ b/lib/deb/s3/templates/package.erb
@@ -34,7 +34,7 @@ Origin: <%= attributes[:deb_origin] %>
 <% end -%>
 Priority: <%= attributes[:deb_priority] %>
 Homepage: <%= url or "http://nourlgiven.example.com/" %>
-Filename: <%= url_filename_encoded %>
+Filename: <%= url_filename %>
 <% if size -%>
 Size: <%= size %>
 <% end -%>


### PR DESCRIPTION
Per https://wiki.debian.org/RepositoryFormat#Filename. It looks like the
transport will then double-escape the URL, causing a 404.

Probably related to krobertson/deb-s3#44.
