### PR TITLE
Added support for origin for the Release file.

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -20,6 +20,11 @@ class Deb::S3::CLI < Thor
   :type     => :string,
   :desc     => "The path prefix to use when storing on S3."
 
+  class_option :origin,
+  :type     => :string,
+  :aliases  => "-o",
+  :desc     => "The origin to use in the repository Release file."
+
   class_option :codename,
   :default  => "stable",
   :type     => :string,
@@ -119,7 +124,7 @@ class Deb::S3::CLI < Thor
 
     # retrieve the existing manifests
     log("Retrieving existing manifests")
-    release  = Deb::S3::Release.retrieve(options[:codename])
+    release  = Deb::S3::Release.retrieve(options[:codename], options[:origin])
     manifests = {}
 
     # examine all the files

--- a/lib/deb/s3/release.rb
+++ b/lib/deb/s3/release.rb
@@ -4,6 +4,7 @@ class Deb::S3::Release
   include Deb::S3::Utils
 
   attr_accessor :codename
+  attr_accessor :origin
   attr_accessor :architectures
   attr_accessor :components
 
@@ -11,6 +12,7 @@ class Deb::S3::Release
   attr_accessor :policy
 
   def initialize
+    @origin = nil
     @codename = nil
     @architectures = []
     @components = []
@@ -19,12 +21,13 @@ class Deb::S3::Release
   end
 
   class << self
-    def retrieve(codename)
+    def retrieve(codename, origin)
       if s = Deb::S3::Utils.s3_read("dists/#{codename}/Release")
         self.parse_release(s)
       else
         rel = self.new
         rel.codename = codename
+        rel.origin = origin unless origin.nil?
         rel
       end
     end
@@ -52,6 +55,7 @@ class Deb::S3::Release
 
     # grab basic fields
     self.codename = parse.call("Codename")
+    self.origin = parse.call("Origin") || nil
     self.architectures = (parse.call("Architectures") || "").split(/\s+/)
     self.components = (parse.call("Components") || "").split(/\s+/)
 

--- a/lib/deb/s3/templates/release.erb
+++ b/lib/deb/s3/templates/release.erb
@@ -1,3 +1,6 @@
+<% if origin -%>
+Origin: <%= origin %>
+<% end -%>
 Codename: <%= codename %>
 Date: <%= Time.now.utc.strftime("%a, %d %b %Y %T %Z") %>
 Architectures: <%= architectures.join(" ") %>


### PR DESCRIPTION
Added the Origin as a command line switch for the Release file, according to the docs Origin is a key/value pair in the Release file. https://wiki.debian.org/RepositoryFormat#A.22Release.22_files

so you can now do 

`deb-s3 --origin=my-origin`

I needed to add this so unattended upgrades can work with custom repos.
