### PR TITLE
Do not escape path in Package file

### DIFF
--- a/lib/deb/s3/package.rb
+++ b/lib/deb/s3/package.rb
@@ -132,7 +132,7 @@ class Deb::S3::Package
   end
 
   def url_filename_encoded
-    @url_filename || "pool/#{self.name[0]}/#{self.name[0..1]}/#{s3_escape(File.basename(self.filename))}"
+    @url_filename || "pool/#{self.name[0]}/#{self.name[0..1]}/#{File.basename(self.filename)}"
   end
 
   def generate


### PR DESCRIPTION
According to https://wiki.debian.org/RepositoryFormat#Filename this path should not be escaped (it breaks download of files with characters that are escaped).