### PR TITLE
Add support for specifying suite in Release file

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -26,6 +26,10 @@ class Deb::S3::CLI < Thor
   :aliases  => "-o",
   :desc     => "The origin to use in the repository Release file."
 
+  class_option :suite,
+  :type     => :string,
+  :desc     => "The suite to use in the repository Release file."
+
   class_option :codename,
   :default  => "stable",
   :type     => :string,
@@ -125,7 +129,7 @@ class Deb::S3::CLI < Thor
 
     # retrieve the existing manifests
     log("Retrieving existing manifests")
-    release  = Deb::S3::Release.retrieve(options[:codename], options[:origin])
+    release  = Deb::S3::Release.retrieve(options[:codename], options[:origin], options[:suite])
     manifests = {}
     release.architectures.each do |arch|
       manifests[arch] = Deb::S3::Manifest.retrieve(options[:codename], component, arch)
@@ -230,7 +234,7 @@ class Deb::S3::CLI < Thor
 
     # retrieve the existing manifests
     log("Retrieving existing manifests")
-    release  = Deb::S3::Release.retrieve(options[:codename], options[:origin])
+    release  = Deb::S3::Release.retrieve(options[:codename], options[:origin], options[:suite])
     manifest = Deb::S3::Manifest.retrieve(options[:codename], component, options[:arch])
 
     deleted = manifest.delete_package(package, versions)
@@ -273,7 +277,7 @@ class Deb::S3::CLI < Thor
     configure_s3_client
 
     log("Retrieving existing manifests")
-    release = Deb::S3::Release.retrieve(options[:codename], options[:origin])
+    release = Deb::S3::Release.retrieve(options[:codename], options[:origin], options[:suite])
 
     release.architectures.each do |arch|
       log("Checking for missing packages in: #{options[:codename]}/#{options[:component]} #{arch}")

--- a/lib/deb/s3/release.rb
+++ b/lib/deb/s3/release.rb
@@ -6,6 +6,7 @@ class Deb::S3::Release
 
   attr_accessor :codename
   attr_accessor :origin
+  attr_accessor :suite
   attr_accessor :architectures
   attr_accessor :components
 
@@ -14,6 +15,7 @@ class Deb::S3::Release
 
   def initialize
     @origin = nil
+    @suite = nil
     @codename = nil
     @architectures = []
     @components = []
@@ -22,13 +24,14 @@ class Deb::S3::Release
   end
 
   class << self
-    def retrieve(codename, origin=nil)
+    def retrieve(codename, origin=nil, suite=nil)
       if s = Deb::S3::Utils.s3_read("dists/#{codename}/Release")
         self.parse_release(s)
       else
         rel = self.new
         rel.codename = codename
         rel.origin = origin
+        rel.suite = suite
         rel
       end
     end
@@ -57,6 +60,7 @@ class Deb::S3::Release
     # grab basic fields
     self.codename = parse.call("Codename")
     self.origin = parse.call("Origin") || nil
+    self.suite = parse.call("Suite") || nil
     self.architectures = (parse.call("Architectures") || "").split(/\s+/)
     self.components = (parse.call("Components") || "").split(/\s+/)
 

--- a/lib/deb/s3/templates/release.erb
+++ b/lib/deb/s3/templates/release.erb
@@ -5,6 +5,7 @@ Codename: <%= codename %>
 Date: <%= Time.now.utc.strftime("%a, %d %b %Y %T %Z") %>
 Architectures: <%= architectures.join(" ") %>
 Components: <%= components.join(" ") %>
+Suite: <%= suite %>
 MD5Sum:
 <% files.sort.each do |f,p| -%>
  <%= p[:md5] %> <%= p[:size].to_s.rjust(16) %> <%= f %>


### PR DESCRIPTION
The `Suite:` field is often used with `unattended-upgrades`, for example `'origin=homeki.com,a=unstable'` where the `a` is the `Suite:` field. This PR adds it in the same way as `Origin:` (which is already there), so it can be specified as `--suite unstable` on the command line.