### PR TITLE
added addition plus to utils.rb in regex because s3 allows plusses in fi...

### DIFF
--- a/lib/deb/s3/utils.rb
+++ b/lib/deb/s3/utils.rb
@@ -49,7 +49,7 @@ module Deb::S3::Utils
 
   # from fog, Fog::AWS.escape
   def s3_escape(string)
-    string.gsub(/([^a-zA-Z0-9_.\-~]+)/) {
+    string.gsub(/([^a-zA-Z0-9_.\-~+]+)/) {
       "%" + $1.unpack("H2" * $1.bytesize).join("%").upcase
     }
   end


### PR DESCRIPTION
added addition plus to utils.rb in regex because s3 allows plusses in files

The bug was

lib32ncurses5_5.9+20140118-1ubuntu1_amd64.deb in package.gz was being modified to lib32ncurses5_5.9%2B20140118-1ubuntu1_amd64.deb (notice the %2B in place of the + ).  S3 actually loads it as lib32ncurses5_5.9+20140118-1ubuntu1_amd64.deb now (with the + sign).

