### PR TITLE
Fixed exponential Package file growth

### DIFF
--- a/lib/deb/s3/package.rb
+++ b/lib/deb/s3/package.rb
@@ -284,7 +284,7 @@ class Deb::S3::Package
           indent, rest = $1, $2
           # Continuation
           if indent.size == 1 && rest == "."
-            value << "\n\n"
+            value << "\n"
             rest = ""
           elsif value.size > 0
             value << "\n"


### PR DESCRIPTION
 - When a "space + dot" is detected in a package description
   it was being replaced by two newlines rather then one.
   then when the control file for the package was being
   generated the decriptions new value would have n ^ 2 dots
   space + dot is intepretted by dpkg as a single newline when
   displaying the extended description, not a double newline.
   As per
   https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Description