### PR TITLE
Fix parsing for blank continuation lines

### DIFF
--- a/lib/deb/s3/package.rb
+++ b/lib/deb/s3/package.rb
@@ -284,7 +284,7 @@ class Deb::S3::Package
           indent, rest = $1, $2
           # Continuation
           if indent.size == 1 && rest == "."
-            value << "\n\n"
+            value << "\n"
             rest = ""
           elsif value.size > 0
             value << "\n"

--- a/spec/deb/s3/package_spec.rb
+++ b/spec/deb/s3/package_spec.rb
@@ -2,6 +2,8 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 require 'deb/s3/package'
 
+EXPECTED_DESCRIPTION = "A platform for community discussion. Free, open, simple.\nThe description can have a continuation line.\n\nAnd blank lines.\n\nIf it wants to."
+
 describe Deb::S3::Package do
   describe ".parse_string" do
     it "creates a Package object with the right attributes" do
@@ -10,6 +12,7 @@ describe Deb::S3::Package do
       package.epoch.must_equal(nil)
       package.iteration.must_equal("1396474125.12e4179.wheezy")
       package.full_version.must_equal("0.9.8.3-1396474125.12e4179.wheezy")
+      package.description.must_equal(EXPECTED_DESCRIPTION)
     end
   end
 

--- a/spec/fixtures/Packages
+++ b/spec/fixtures/Packages
@@ -16,3 +16,8 @@ SHA1: 919b7b7860ed0f5850d031072c00a64c6f41657a
 SHA256: ab79c879c498086b62289da77d770725939acababcbcd8d8af5cf46e1971fd0e
 MD5sum: 11aa00eeb849212667d81ce1904daa4d
 Description: A platform for community discussion. Free, open, simple.
+ The description can have a continuation line.
+ .
+ And blank lines.
+ .
+ If it wants to.


### PR DESCRIPTION
The original logic injected two newlines if it ever saw a continuation
line that contained a single dot. Unfortunately, this doubled the
number of empty continuation lines every time a package was uploaded.

Fixes #72