### PR TITLE
Fixing the deletion of a package

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -230,7 +230,7 @@ class Deb::S3::CLI < Thor
 
     # retrieve the existing manifests
     log("Retrieving existing manifests")
-    release  = Deb::S3::Release.retrieve(options[:codename])
+    release  = Deb::S3::Release.retrieve(options[:codename], options[:origin])
     manifest = Deb::S3::Manifest.retrieve(options[:codename], component, options[:arch])
 
     deleted = manifest.delete_package(package, versions)

--- a/lib/deb/s3/manifest.rb
+++ b/lib/deb/s3/manifest.rb
@@ -66,7 +66,7 @@ class Deb::S3::Manifest
         if p.name != pkg
            p
         # Also include the packages not matching a specified version
-        elsif (!versions.nil? and p.name == pkg and !versions.include? p.version)
+        elsif (!versions.nil? and p.name == pkg and versions.select{|v| !v.include? p.version}.length > 0)
             p
         end
     }


### PR DESCRIPTION
Versions are handled as an array, the filtering of the packages was applied as if it was a simple string causing it to not filter anything.