### PR TITLE
Add bucket_owner_full_control to ACL options.

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -522,8 +522,10 @@ class Deb::S3::CLI < Thor
         :private
       when "authenticated"
         :authenticated_read
+      when "bucket_owner"
+        :bucket_owner_full_control
       else
-        error("Invalid visibility setting given. Can be public, private, or authenticated.")
+        error("Invalid visibility setting given. Can be public, private, authenticated, or bucket_owner.")
       end
   end
 end


### PR DESCRIPTION
I've found a situation where using authenticated or private does not work.  I've got a test/dev AWS account, and if I use IAM roles to allow that account to push to my production repo, I can no longer update the packages.  
The bucket_owner_full_control ACL option allows this.
