### PR TITLE
rollback 014ef3f per issue #44

### DIFF
--- a/lib/deb/s3/templates/package.erb
+++ b/lib/deb/s3/templates/package.erb
@@ -40,7 +40,7 @@ Origin: <%= attributes[:deb_origin] %>
 <% end -%>
 Priority: <%= attributes[:deb_priority] %>
 Homepage: <%= url or "http://nourlgiven.example.com/" %>
-Filename: <%= url_filename_encoded %>
+Filename: <%= url_filename %>
 <% if size -%>
 Size: <%= size %>
 <% end -%>


### PR DESCRIPTION
Per the issue and the Debian repo spec. The filename in the package description should _not_ be url encoded. 

I have tested this on my repository and the patch fixes the issue.
