### PR TITLE
The .deb files weren't honouring the cache-control

### DIFF
--- a/lib/deb/s3/manifest.rb
+++ b/lib/deb/s3/manifest.rb
@@ -88,7 +88,7 @@ class Deb::S3::Manifest
     # store any packages that need to be stored
     @packages_to_be_upload.each do |pkg|
       yield pkg.url_filename if block_given?
-      s3_store(pkg.filename, pkg.url_filename, 'application/octet-stream; charset=binary')
+      s3_store(pkg.filename, pkg.url_filename, 'application/octet-stream; charset=binary', self.cache_control)
     end
 
     # generate the Packages file


### PR DESCRIPTION
 - This directive wasn't being propagated to the pool, only the release
   and packages files were using the CLI param --cache-control