### PR TITLE
Change content-type for Packages and Release files to text/plain

### DIFF
--- a/lib/deb/s3/manifest.rb
+++ b/lib/deb/s3/manifest.rb
@@ -97,7 +97,7 @@ class Deb::S3::Manifest
     pkgs_temp.close
     f = "dists/#{@codename}/#{@component}/binary-#{@architecture}/Packages"
     yield f if block_given?
-    s3_store(pkgs_temp.path, f, 'binary/octet-stream; charset=binary', self.cache_control)
+    s3_store(pkgs_temp.path, f, 'text/plain; charset=UTF-8', self.cache_control)
     @files["#{@component}/binary-#{@architecture}/Packages"] = hashfile(pkgs_temp.path)
     pkgs_temp.unlink
 

--- a/lib/deb/s3/release.rb
+++ b/lib/deb/s3/release.rb
@@ -98,7 +98,7 @@ class Deb::S3::Release
     release_tmp.puts self.generate
     release_tmp.close
     yield self.filename if block_given?
-    s3_store(release_tmp.path, self.filename, 'binary/octet-stream; charset=binary', self.cache_control)
+    s3_store(release_tmp.path, self.filename, 'text/plain; charset=UTF-8', self.cache_control)
 
     # sign the file, if necessary
     if Deb::S3::Utils.signing_key


### PR DESCRIPTION
This will solve the issue #78 . I saw similar change for content-types were done previously in PR #28, not sure when it got lost. Also I have used `UTF-8` instead `us-ascii` as ASCII is a sub-set of UTF-8 anyway, plus it might be that maintainer name can include some special characters (ą, ł, ę, etc.). But if I am missing something here I might set it to ASCII. I have tested in on S3 bucket and works as expected (files display in the browser instead of being downloaded).
