### PR TITLE
Handle full version in package deletion

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -396,7 +396,7 @@ class Deb::S3::CLI < Thor
         end
     else
         deleted.each { |p|
-            sublog("Deleting #{p.name} version #{p.version}")
+            sublog("Deleting #{p.name} version #{p.full_version}")
         }
     end
 

--- a/lib/deb/s3/manifest.rb
+++ b/lib/deb/s3/manifest.rb
@@ -69,7 +69,7 @@ class Deb::S3::Manifest
         if p.name != pkg
            p
         # Also include the packages not matching a specified version
-        elsif (!versions.nil? and p.name == pkg and !versions.include?(p.version) and !versions.include?("#{p.version}-#{p.iteration}"))
+        elsif (!versions.nil? and p.name == pkg and !versions.include?(p.version) and !versions.include?("#{p.version}-#{p.iteration}") and !versions.include?(p.full_version))
             p
         end
     }

--- a/spec/deb/s3/manifest_spec.rb
+++ b/spec/deb/s3/manifest_spec.rb
@@ -43,4 +43,28 @@ describe Deb::S3::Manifest do
       end
     end
   end
+
+  describe "#delete_package" do
+    it "removes packages which have the same version as one of the versions specified" do
+      epoch = Time.now.to_i
+      existing_packages_with_same_version = [
+        create_package(:name => "discourse", :epoch => epoch, :version => "0.9.8.3", :iteration => "1"),
+        create_package(:name => "discourse", :epoch => epoch, :version => "0.9.0.0", :iteration => "1"),
+        create_package(:name => "discourse", :epoch => epoch, :version => "0.9.0.0", :iteration => "2"),
+      ]
+      existing_packages_with_different_version = [
+        create_package(:name => "discourse", :epoch => epoch, :version => "0.9.8.3", :iteration => "2"),
+      ]
+      versions_to_delete = ["#{epoch}:0.9.8.3-1", "0.9.0.0"]
+
+      # We set the attribute instead of stubbing it so that it can be re-assigned in `delete_package`
+      @manifest.instance_variable_set(:@packages, existing_packages_with_same_version + existing_packages_with_different_version)
+
+      @manifest.delete_package("discourse", versions_to_delete)
+      @manifest.packages.must_equal existing_packages_with_different_version
+
+      # Reset the attribute
+      @manifest.instance_variable_set(:@packages, [])
+    end
+  end
 end


### PR DESCRIPTION
Allows to specify full versions (`epoch:version-iteration`) in the
`versions` option. To preserve BC, specifying a short version (`version`
or `version-iteration`) will still delete the packages that have
full versions.

Also added a test for the change.