### PR TITLE
Add locking support

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -139,83 +139,87 @@ class Deb::S3::CLI < Thor
     # configure AWS::S3
     configure_s3_client
 
-    if options[:lock]
-      log("Checking for existing lock file")
-      if Deb::S3::Lock.locked?(options[:codename], component, options[:arch], options[:cache_control])
-        lock = Deb::S3::Lock.current(options[:codename], component, options[:arch], options[:cache_control])
-        log("Repository is locked by another user: #{lock.user} at host #{lock.host}")
-        log("Attempting to obtain a lock")
-        Deb::S3::Lock.wait_for_lock(options[:codename], component, options[:arch], options[:cache_control])
-      end
-      log("Locking repository for updates")
-      Deb::S3::Lock.lock(options[:codename], component, options[:arch], options[:cache_control])
-    end
-
-
-    # retrieve the existing manifests
-    log("Retrieving existing manifests")
-    release  = Deb::S3::Release.retrieve(options[:codename], options[:origin], options[:suite], options[:cache_control])
-    manifests = {}
-    release.architectures.each do |arch|
-      manifests[arch] = Deb::S3::Manifest.retrieve(options[:codename], component, arch, options[:cache_control])
-    end
-
-    packages_arch_all = []
-
-    # examine all the files
-    files.collect { |f| Dir.glob(f) }.flatten.each do |file|
-      log("Examining package file #{File.basename(file)}")
-      pkg = Deb::S3::Package.parse_file(file)
-
-      # copy over some options if they weren't given
-      arch = options[:arch] || pkg.architecture
-
-      # validate we have them
-      error("No architcture given and unable to determine one for #{file}. " +
-            "Please specify one with --arch [i386|amd64].") unless arch
-
-      # If the arch is all and the list of existing manifests is none, then
-      # throw an error. This is mainly the case when initializing a brand new
-      # repository. With "all", we won't know which architectures they're using.
-      if arch == "all" && manifests.count == 0
-        error("Package #{File.basename(file)} had architecture \"all\", " +
-              "however noexisting package lists exist. This can often happen " +
-              "if the first package you are add to a new repository is an " +
-              "\"all\" architecture file. Please use --arch [i386|amd64] or " +
-              "another platform type to upload the file.")
+    begin
+      if options[:lock]
+        log("Checking for existing lock file")
+        if Deb::S3::Lock.locked?(options[:codename], component, options[:arch], options[:cache_control])
+          lock = Deb::S3::Lock.current(options[:codename], component, options[:arch], options[:cache_control])
+          log("Repository is locked by another user: #{lock.user} at host #{lock.host}")
+          log("Attempting to obtain a lock")
+          Deb::S3::Lock.wait_for_lock(options[:codename], component, options[:arch], options[:cache_control])
+        end
+        log("Locking repository for updates")
+        Deb::S3::Lock.lock(options[:codename], component, options[:arch], options[:cache_control])
+        @lock_acquired = true
       end
 
-      # retrieve the manifest for the arch if we don't have it already
-      manifests[arch] ||= Deb::S3::Manifest.retrieve(options[:codename], component, arch, options[:cache_control])
 
-      # add package in manifests
-      manifests[arch].add(pkg, options[:preserve_versions])
-
-      # If arch is all, we must add this package in all arch available
-      if arch == 'all'
-        packages_arch_all << pkg
+      # retrieve the existing manifests
+      log("Retrieving existing manifests")
+      release  = Deb::S3::Release.retrieve(options[:codename], options[:origin], options[:suite], options[:cache_control])
+      manifests = {}
+      release.architectures.each do |arch|
+        manifests[arch] = Deb::S3::Manifest.retrieve(options[:codename], component, arch, options[:cache_control])
       end
-    end
 
-    manifests.each do |arch, manifest|
-      next if arch == 'all'
-      packages_arch_all.each do |pkg|
-        manifest.add(pkg, options[:preserve_versions], false)
+      packages_arch_all = []
+
+      # examine all the files
+      files.collect { |f| Dir.glob(f) }.flatten.each do |file|
+        log("Examining package file #{File.basename(file)}")
+        pkg = Deb::S3::Package.parse_file(file)
+
+        # copy over some options if they weren't given
+        arch = options[:arch] || pkg.architecture
+
+        # validate we have them
+        error("No architcture given and unable to determine one for #{file}. " +
+              "Please specify one with --arch [i386|amd64].") unless arch
+
+        # If the arch is all and the list of existing manifests is none, then
+        # throw an error. This is mainly the case when initializing a brand new
+        # repository. With "all", we won't know which architectures they're using.
+        if arch == "all" && manifests.count == 0
+          error("Package #{File.basename(file)} had architecture \"all\", " +
+                "however noexisting package lists exist. This can often happen " +
+                "if the first package you are add to a new repository is an " +
+                "\"all\" architecture file. Please use --arch [i386|amd64] or " +
+                "another platform type to upload the file.")
+        end
+
+        # retrieve the manifest for the arch if we don't have it already
+        manifests[arch] ||= Deb::S3::Manifest.retrieve(options[:codename], component, arch, options[:cache_control])
+
+        # add package in manifests
+        manifests[arch].add(pkg, options[:preserve_versions])
+
+        # If arch is all, we must add this package in all arch available
+        if arch == 'all'
+          packages_arch_all << pkg
+        end
       end
-    end
 
-    # upload the manifest
-    log("Uploading packages and new manifests to S3")
-    manifests.each_value do |manifest|
-      manifest.write_to_s3 { |f| sublog("Transferring #{f}") }
-      release.update_manifest(manifest)
-    end
-    release.write_to_s3 { |f| sublog("Transferring #{f}") }
+      manifests.each do |arch, manifest|
+        next if arch == 'all'
+        packages_arch_all.each do |pkg|
+          manifest.add(pkg, options[:preserve_versions], false)
+        end
+      end
 
-    log("Update complete.")
-    if options[:lock]
-      Deb::S3::Lock.unlock(options[:codename], component, options[:arch], options[:cache_control])
-      log("Lock released.")
+      # upload the manifest
+      log("Uploading packages and new manifests to S3")
+      manifests.each_value do |manifest|
+        manifest.write_to_s3 { |f| sublog("Transferring #{f}") }
+        release.update_manifest(manifest)
+      end
+      release.write_to_s3 { |f| sublog("Transferring #{f}") }
+
+      log("Update complete.")
+    ensure
+      if options[:lock] && @lock_acquired
+        Deb::S3::Lock.unlock(options[:codename], component, options[:arch], options[:cache_control])
+        log("Lock released.")
+      end
     end
   end
 

--- a/lib/deb/s3/lock.rb
+++ b/lib/deb/s3/lock.rb
@@ -1,0 +1,58 @@
+# -*- encoding : utf-8 -*-
+require "tempfile"
+require "socket"
+require "etc"
+
+class Deb::S3::Lock
+  attr_accessor :user
+  attr_accessor :host
+
+  def initialize
+    @user = nil
+    @host = nil
+  end
+
+  class << self
+    def locked?(codename, component = nil, architecture = nil, cache_control = nil)
+      Deb::S3::Utils.s3_exists?(lock_path(codename, component, architecture, cache_control))
+    end
+
+    def wait_for_lock(codename, component = nil, architecture = nil, cache_control = nil, max_attempts=60, wait=10)
+      attempts = 0
+      while self.locked?(codename, component, architecture, cache_control) do
+        attempts += 1
+        throw "Unable to obtain a lock after #{max_attempts}, giving up." if attempts > max_attempts
+        sleep(wait)
+      end
+    end
+
+    def lock(codename, component = nil, architecture = nil, cache_control = nil)
+      lockfile = Tempfile.new("lockfile")
+      lockfile.write("#{Etc.getlogin}@#{Socket.gethostname}")
+      lockfile.close
+
+      Deb::S3::Utils.s3_store(lockfile.path,
+                              lock_path(codename, component, architecture, cache_control),
+                              "text/plain",
+                              cache_control)
+    end
+
+    def unlock(codename, component = nil, architecture = nil, cache_control = nil)
+      Deb::S3::Utils.s3_remove(lock_path(codename, component, architecture, cache_control))
+    end
+
+    def current(codename, component = nil, architecture = nil, cache_control = nil)
+      lock_content = Deb::S3::Utils.s3_read(lock_path(codename, component, architecture, cache_control))
+      lock_content = lock_content.split('@')
+      lock = Deb::S3::Lock.new
+      lock.user = lock_content[0]
+      lock.host = lock_content[1] if lock_content.size > 1
+      lock
+    end
+
+    private
+    def lock_path(codename, component = nil, architecture = nil, cache_control = nil)
+      "dists/#{codename}/#{component}/binary-#{architecture}/lockfile"
+    end
+  end
+end

--- a/spec/deb/s3/lock_spec.rb
+++ b/spec/deb/s3/lock_spec.rb
@@ -1,0 +1,64 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path('../../../spec_helper', __FILE__)
+require 'deb/s3/lock'
+require 'minitest/mock'
+
+describe Deb::S3::Lock do
+  describe :locked? do
+    it 'returns true if lock file exists' do
+      Deb::S3::Utils.stub :s3_exists?, true do
+        Deb::S3::Lock.locked?("stable").must_equal true
+      end
+    end
+    it 'returns true if lock file exists' do
+      Deb::S3::Utils.stub :s3_exists?, false do
+        Deb::S3::Lock.locked?("stable").must_equal false
+      end
+    end
+  end
+
+  describe :lock do
+    it 'creates a lock file' do
+      mock = MiniTest::Mock.new
+      mock.expect(:call, nil, 4.times.map {Object})
+      Deb::S3::Utils.stub :s3_store, mock do
+        Deb::S3::Lock.lock("stable")
+      end
+      mock.verify
+    end
+  end
+
+  describe :unlock do
+    it 'deletes the lock file' do
+      mock = MiniTest::Mock.new
+      mock.expect(:call, nil, [String])
+      Deb::S3::Utils.stub :s3_remove, mock do
+        Deb::S3::Lock.unlock("stable")
+      end
+      mock.verify
+    end
+  end
+
+  describe :current do
+    before :each do
+      mock = MiniTest::Mock.new
+      mock.expect(:call, "alex@localhost", [String])
+      Deb::S3::Utils.stub :s3_read, mock do
+        @lock = Deb::S3::Lock.current("stable")
+      end
+    end
+
+    it 'returns a lock object' do
+      @lock.must_be_instance_of Deb::S3::Lock
+    end
+
+    it 'holds the user who currently holds the lock' do
+      @lock.user.must_equal 'alex'
+    end
+
+    it 'holds the hostname from where the lock was set' do
+      @lock.host.must_equal 'localhost'
+    end
+  end
+
+end


### PR DESCRIPTION
Implemented locking mechanism to prevent simultaneous updates from corrupting index. It is used optionally with the -l option.

Previously if 2 users were to update the repository in S3 at the same time, one of the packages would end up missing from Packages.gz and Release.

I've tried to follow the existing code as closely as possible, and added MiniTest specs for the extra code.