### PR TITLE
Add support for the s3_force_path_style option for the s3 client

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -64,7 +64,7 @@ class Deb::S3::CLI < Thor
   class_option :force_path_style,
   :default  => false,
   :type     => :boolean,
-  :desc     => "Use S3 path style instead on subdomains."
+  :desc     => "Use S3 path style instead of subdomains."
 
   class_option :proxy_uri,
   :type     => :string,

--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -61,6 +61,11 @@ class Deb::S3::CLI < Thor
   :desc     => "The region endpoint for connecting to S3.",
   :default  => "s3.amazonaws.com"
 
+  class_option :force_path_style,
+  :default  => false,
+  :type     => :boolean,
+  :desc     => "Use S3 path style instead on subdomains."
+
   class_option :proxy_uri,
   :type     => :string,
   :desc     => "The URI of the proxy to send service requests through."
@@ -565,7 +570,8 @@ class Deb::S3::CLI < Thor
     settings = {
       :s3_endpoint => options[:endpoint],
       :proxy_uri   => options[:proxy_uri],
-      :use_ssl     => options[:use_ssl]
+      :use_ssl     => options[:use_ssl],
+      :s3_force_path_style => options[:force_path_style]
     }
     settings.merge!(provider.credentials)
 


### PR DESCRIPTION
This is mostly useful for local development or testing (fake s3 or
likewise). This option is needed if subdomains are not mapped
(*.s3.lancehudson.com) or if using those domains would cause ssl
errors (test.lancehudson.com.s3.amazon.com).