### PR TITLE
Fixed crash when `--fail_if_exists` during copy

### DIFF
--- a/lib/deb/s3/manifest.rb
+++ b/lib/deb/s3/manifest.rb
@@ -56,7 +56,15 @@ class Deb::S3::Manifest
 
   def add(pkg, preserve_versions, needs_uploading=true)
     if self.fail_if_exists
-      packages.each { |p| raise AlreadyExistsError, "package #{pkg.name}_#{pkg.full_version} already exists with different filename (#{p.url_filename})" if p.name == pkg.name && p.full_version == pkg.full_version && File.basename(p.url_filename) != File.basename(pkg.filename) }
+      packages.each { |p|
+        next unless p.name == pkg.name && \
+                    p.full_version == pkg.full_version && \
+                    File.basename(p.url_filename) != \
+                    File.basename(pkg.url_filename)
+        raise AlreadyExistsError,
+              "package #{pkg.name}_#{pkg.full_version} already exists " \
+              "with different filename (#{p.url_filename})"
+      }
     end
     if preserve_versions
       packages.delete_if { |p| p.name == pkg.name && p.full_version == pkg.full_version }


### PR DESCRIPTION
It appears to be comparing a (possibly nil) `filename` with a
`url_filename`. Now compares like for like. Crash I experienced:
```
/var/lib/gems/2.0.0/gems/deb-s3-0.8.0/lib/deb/s3/manifest.rb:59:in `basename': no implicit conversion of nil into String (TypeError)
from /var/lib/gems/2.0.0/gems/deb-s3-0.8.0/lib/deb/s3/manifest.rb:59:in `block in add'
from /var/lib/gems/2.0.0/gems/deb-s3-0.8.0/lib/deb/s3/manifest.rb:59:in `each'
from /var/lib/gems/2.0.0/gems/deb-s3-0.8.0/lib/deb/s3/manifest.rb:59:in `add'
from /var/lib/gems/2.0.0/gems/deb-s3-0.8.0/lib/deb/s3/cli.rb:405:in `block in copy'
from /var/lib/gems/2.0.0/gems/deb-s3-0.8.0/lib/deb/s3/cli.rb:403:in `each'
from /var/lib/gems/2.0.0/gems/deb-s3-0.8.0/lib/deb/s3/cli.rb:403:in `copy'
from /var/lib/gems/2.0.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
from /var/lib/gems/2.0.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
from /var/lib/gems/2.0.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
from /var/lib/gems/2.0.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
from /var/lib/gems/2.0.0/gems/deb-s3-0.8.0/bin/deb-s3:8:in `<top (required)>'
from /usr/local/bin/deb-s3:23:in `load'
from /usr/local/bin/deb-s3:23:in `<main>'
```