### PR TITLE
Lock should be enabled by default 

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -125,7 +125,7 @@ class Deb::S3::CLI < Thor
     "in the repository when uploading one."
 
   option :lock,
-  :default  => false,
+  :default  => true,
   :type     => :boolean,
   :aliases  => "-l",
   :desc     => "Whether to check for an existing lock on the repository " +


### PR DESCRIPTION
I ran into issues where having multiple running deb-s3 uploads would trigger
`...binary-amd64/Packages Hash Sum mismatch`. Of course putting a lock in place would prevent this problem. This PR just enables it by default
