### PR TITLE
Allow updating of Codename, Origin and Suite in Release even if it already exists

### DIFF
--- a/lib/deb/s3/release.rb
+++ b/lib/deb/s3/release.rb
@@ -31,10 +31,10 @@ class Deb::S3::Release
         rel = self.parse_release(s)
       else
         rel = self.new
-        rel.codename = codename
-        rel.origin = origin unless origin.nil?
-        rel.suite = suite unless suite.nil?
       end
+      rel.codename = codename
+      rel.origin = origin unless origin.nil?
+      rel.suite = suite unless suite.nil?
       rel.cache_control = cache_control
       rel
     end


### PR DESCRIPTION
Unsure if this is a bad thing to do, but I needed this added to a Releases file for an already existing repository.  This fix allows this to happen directly from `deb-s3` with the `--{codename,origin,suite}` options.