### PR TITLE
Also sign InRelease for Jessie & Stretch (not just Xenial)

### DIFF
--- a/lib/deb/s3/release.rb
+++ b/lib/deb/s3/release.rb
@@ -103,7 +103,7 @@ class Deb::S3::Release
     # sign the file, if necessary
     if Deb::S3::Utils.signing_key
       key_param = Deb::S3::Utils.signing_key != "" ? "--default-key=#{Deb::S3::Utils.signing_key}" : ""
-      if self.codename == "xenial"
+      if self.codename == "xenial" || self.codename == "jessie" || self.codename == "stretch"
         if system("gpg -a #{key_param} #{Deb::S3::Utils.gpg_options} -s --clearsign #{release_tmp.path}")
           local_file = release_tmp.path+".asc"
           remote_file = "dists/#{@codename}/InRelease"


### PR DESCRIPTION
InRelease is only signed for Xenial due the logic on line 106.

This change causes it to also be signed for Debian Jessie & Stretch.

Its not the most elegant fix, An array of release names that require InRelease signing should probably be set somewhere and `if release_array.include? "self.codename" ` used.

I also had to regenerate the signing key to sign with SHA-256 by adding these lines to `~/.gnupg/gpg.conf`

After this my apt updates worked with 0 errors.

```
personal-digest-preferences SHA256
cert-digest-algo SHA256
```