### PR TITLE
Update encryption flag to support aws-sdk v2

### DIFF
--- a/lib/deb/s3/utils.rb
+++ b/lib/deb/s3/utils.rb
@@ -97,7 +97,7 @@ module Deb::S3::Utils
     end
 
     # specify if encryption is required
-    options[:server_side_encryption] = :aes256 if Deb::S3::Utils.encryption
+    options[:server_side_encryption] = "AES256" if Deb::S3::Utils.encryption
 
     # upload the file
     File.open(path) do |f|


### PR DESCRIPTION
Hi,

It seemed like the `--encryption` flag was no longer supported due to an issue with v2 of the AWS SDK.

Googling around, I found https://github.com/thoughtbot/paperclip/wiki/Upgrade-Paperclip-4x-to-5x which mentions 

> Note that AWS no longer accepts :aes256 as an encryption value and will raise Aws::S3::Errors::InvalidArgument with the message The encryption method specified is not supported. The value should instead be "AES256".

...which also seems to be backed up by http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Object.html

> Possible values:
>
> AES256
> aws:kms

I don't really know Ruby, but I updated `:aes256` to `"AES256"` and `--encryption` seems to work for me, so I'm hoping this helps someone else.