### PR TITLE
Fixed upload with relative path

### DIFF
--- a/bin/deb-s3
+++ b/bin/deb-s3
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
-$:.unshift File.expand_path('../../lib', __FILE__)
+require 'pathname'
+$:.unshift File.join(Pathname.new(__FILE__).realpath,'../../lib')
 
 require 'rubygems'
 require 'deb/s3/cli'

--- a/lib/deb/s3/utils.rb
+++ b/lib/deb/s3/utils.rb
@@ -75,7 +75,7 @@ module Deb::S3::Utils
 
   def s3_store(path, filename=nil, content_type='application/octet-stream; charset=binary', cache_control=nil, fail_if_exists=false)
     filename = File.basename(path) unless filename
-    obj = s3_exists?(path)
+    obj = s3_exists?(filename)
 
     file_md5 = Digest::MD5.file(path)
 


### PR DESCRIPTION
- Fixes #124
- Fixed - `s3_store` to pass correct filename to `s3_exists`.
  Bumped into this by trying to upload a package by specifying a path like `../package.deb`.
- Set to absolute path so we can use symlinks to deb-s3