### PR TITLE
Fix --fail-if-exists

### DIFF
--- a/lib/deb/s3/utils.rb
+++ b/lib/deb/s3/utils.rb
@@ -82,7 +82,7 @@ module Deb::S3::Utils
     # check if the object already exists
     if obj != false
       return if (file_md5.to_s == obj[:etag].gsub('"', '') or file_md5.to_s == obj[:metadata]['md5'])
-      raise AlreadyExistsError, "file #{obj.public_url} already exists with different contents" if fail_if_exists
+      raise AlreadyExistsError, "file #{filename} already exists with different contents" if fail_if_exists
     end
 
     options = {


### PR DESCRIPTION
When --fail-if-exists is in effect, the code makes a HEAD request to
check if the object exists and has the same md5, but uses the results of
that request to write the name of the object via the `public_url` method
(that only applies to GET request results).

As we already have the filename in the method, just use that directly in
the message instead of an object property.

Fixes #10.

Signed-off-by: L. Alberto Giménez <alberto.gimenez@capside.com>