### PR TITLE
Include codename in pool filename

### DIFF
--- a/lib/deb/s3/manifest.rb
+++ b/lib/deb/s3/manifest.rb
@@ -62,11 +62,11 @@ class Deb::S3::Manifest
       packages.each { |p|
         next unless p.name == pkg.name && \
                     p.full_version == pkg.full_version && \
-                    File.basename(p.url_filename) != \
-                    File.basename(pkg.url_filename)
+                    File.basename(p.url_filename(@codename)) != \
+                    File.basename(pkg.url_filename(@codename))
         raise AlreadyExistsError,
               "package #{pkg.name}_#{pkg.full_version} already exists " \
-              "with different filename (#{p.url_filename})"
+              "with different filename (#{p.url_filename(@codename)})"
       }
     end
     if preserve_versions
@@ -96,7 +96,7 @@ class Deb::S3::Manifest
   end
 
   def generate
-    @packages.collect { |pkg| pkg.generate }.join("\n")
+    @packages.collect { |pkg| pkg.generate(@codename) }.join("\n")
   end
 
   def write_to_s3
@@ -105,8 +105,8 @@ class Deb::S3::Manifest
     unless self.skip_package_upload
       # store any packages that need to be stored
       @packages_to_be_upload.each do |pkg|
-        yield pkg.url_filename if block_given?
-        s3_store(pkg.filename, pkg.url_filename, 'application/octet-stream; charset=binary', self.cache_control, self.fail_if_exists)
+        yield pkg.url_filename(@codename) if block_given?
+        s3_store(pkg.filename, pkg.url_filename(@codename), 'application/octet-stream; charset=binary', self.cache_control, self.fail_if_exists)
       end
     end
 

--- a/lib/deb/s3/package.rb
+++ b/lib/deb/s3/package.rb
@@ -127,15 +127,15 @@ class Deb::S3::Package
     @filename
   end
 
-  def url_filename
-    @url_filename || "pool/#{self.name[0]}/#{self.name[0..1]}/#{File.basename(self.filename)}"
+  def url_filename(codename)
+    @url_filename || "pool/#{codename}/#{self.name[0]}/#{self.name[0..1]}/#{File.basename(self.filename)}"
   end
 
-  def url_filename_encoded
-    @url_filename || "pool/#{self.name[0]}/#{self.name[0..1]}/#{s3_escape(File.basename(self.filename))}"
+  def url_filename_encoded(codename)
+    @url_filename || "pool/#{codename}/#{self.name[0]}/#{self.name[0..1]}/#{s3_escape(File.basename(self.filename))}"
   end
 
-  def generate
+  def generate(codename)
     template("package.erb").result(binding)
   end
 

--- a/lib/deb/s3/templates/package.erb
+++ b/lib/deb/s3/templates/package.erb
@@ -40,7 +40,7 @@ Origin: <%= attributes[:deb_origin] %>
 <% end -%>
 Priority: <%= attributes[:deb_priority] %>
 Homepage: <%= url or "http://nourlgiven.example.com/" %>
-Filename: <%= url_filename_encoded %>
+Filename: <%= url_filename_encoded(codename) %>
 <% if size -%>
 Size: <%= size %>
 <% end -%>


### PR DESCRIPTION
Prevents pool conflicts when releasing for multiple distributions.

Closes #55.

I've never written any ruby before, do let me know if there are better/easier ways to do this :see_no_evil: