### PR TITLE
Clarify --fail-if-exists effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Options:
   -a, [--arch=ARCH]                                        # The architecture of the package in the APT repository.
   -p, [--preserve-versions], [--no-preserve-versions]      # Whether to preserve other versions of a package in the repository when uploading one.
   -l, [--lock], [--no-lock]                                # Whether to check for an existing lock on the repository to prevent simultaneous updates
-      [--fail-if-exists], [--no-fail-if-exists]            # Whether to overwrite any existing package that has the same filename in the pool or the same name and version in the manifest.
+      [--fail-if-exists], [--no-fail-if-exists]            # Whether to overwrite any existing package that has the same filename in the pool or the same name and version in the manifest but different contents.
       [--skip-package-upload], [--no-skip-package-upload]  # Whether to skip all package uploads.This is useful when hosting .deb files outside of the bucket.
   -b, [--bucket=BUCKET]                                    # The name of the S3 bucket to upload to.
       [--prefix=PREFIX]                                    # The path prefix to use when storing on S3.

--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -138,7 +138,8 @@ class Deb::S3::CLI < Thor
   :default  => false,
   :type     => :boolean,
   :desc     => "Whether to overwrite any existing package that has the same " +
-    "filename in the pool or the same name and version in the manifest."
+    "filename in the pool or the same name and version in the manifest but " +
+	"different contents."
 
   option :skip_package_upload,
   :default  => false,


### PR DESCRIPTION
When the switch is enabled, and a package is uploaded with the same
version **and contents**, it will not actually fail.

It only has effect when the uploaded package matches an existing package
in the pool or manifest, but the contents are different.

Clarify commandline reference as well as README.

Closes #136.

Signed-off-by: L. Alberto Giménez <alberto.gimenez@capside.com>