### PR TITLE
Use lowercase charset in Content-Type

### DIFF
--- a/lib/deb/s3/manifest.rb
+++ b/lib/deb/s3/manifest.rb
@@ -116,7 +116,7 @@ class Deb::S3::Manifest
     pkgs_temp.close
     f = "dists/#{@codename}/#{@component}/binary-#{@architecture}/Packages"
     yield f if block_given?
-    s3_store(pkgs_temp.path, f, 'text/plain; charset=UTF-8', self.cache_control)
+    s3_store(pkgs_temp.path, f, 'text/plain; charset=utf-8', self.cache_control)
     @files["#{@component}/binary-#{@architecture}/Packages"] = hashfile(pkgs_temp.path)
     pkgs_temp.unlink
 

--- a/lib/deb/s3/release.rb
+++ b/lib/deb/s3/release.rb
@@ -98,7 +98,7 @@ class Deb::S3::Release
     release_tmp.puts self.generate
     release_tmp.close
     yield self.filename if block_given?
-    s3_store(release_tmp.path, self.filename, 'text/plain; charset=UTF-8', self.cache_control)
+    s3_store(release_tmp.path, self.filename, 'text/plain; charset=utf-8', self.cache_control)
 
     # sign the file, if necessary
     if Deb::S3::Utils.signing_key


### PR DESCRIPTION
Using uppercase UTF-8 in Conent-Type lead to signature verification failure in some third party S3 vendors, i.e. Quobyte. According to W3C charset value here is case-insensitive, so we don't break anything here with this PR, just support non-RFC compliant S3 implementations.