### PR TITLE
fix Content-Type to same type as official repository

### DIFF
--- a/lib/deb/s3/manifest.rb
+++ b/lib/deb/s3/manifest.rb
@@ -106,7 +106,7 @@ class Deb::S3::Manifest
       # store any packages that need to be stored
       @packages_to_be_upload.each do |pkg|
         yield pkg.url_filename(@codename) if block_given?
-        s3_store(pkg.filename, pkg.url_filename(@codename), 'application/octet-stream; charset=binary', self.cache_control, self.fail_if_exists)
+        s3_store(pkg.filename, pkg.url_filename(@codename), 'application/x-debian-package', self.cache_control, self.fail_if_exists)
       end
     end
 
@@ -126,7 +126,7 @@ class Deb::S3::Manifest
     Zlib::GzipWriter.open(gztemp.path) { |gz| gz.write manifest }
     f = "dists/#{@codename}/#{@component}/binary-#{@architecture}/Packages.gz"
     yield f if block_given?
-    s3_store(gztemp.path, f, 'application/x-gzip; charset=binary', self.cache_control)
+    s3_store(gztemp.path, f, 'application/x-gzip', self.cache_control)
     @files["#{@component}/binary-#{@architecture}/Packages.gz"] = hashfile(gztemp.path)
     gztemp.unlink
 


### PR DESCRIPTION
I think the Content-Type should be same as official repository.
https://gist.github.com/mtanda/5d02c0b2b6a8f8abfd2bfe1ec519641d

The motivation to fix Content-Type is, I want to access S3 hosted repository from API Gateway.
https://docs.aws.amazon.com/apigateway/latest/developerguide/integrating-api-with-aws-services-s3.html

I'm not sure why `charset=binary` is set, but it cause error when I access S3 via API Gateway.
The error message is `Charset is invalid or illegal`.
When I remove `charset=binary` from Content-Type, I can access S3 repository.
