### PR TITLE
Ensure only one lock is written

### DIFF
--- a/lib/deb/s3/lock.rb
+++ b/lib/deb/s3/lock.rb
@@ -50,7 +50,7 @@ class Deb::S3::Lock
 
     def current(codename, component = nil, architecture = nil, cache_control = nil)
       lock_content = Deb::S3::Utils.s3_read(lock_path(codename, component, architecture, cache_control))
-      lock_content = lock_content.split('@')
+      lock_content = lock_content.split('_').first.split('@')
       lock = Deb::S3::Lock.new
       lock.user = lock_content[0]
       lock.host = lock_content[1] if lock_content.size > 1

--- a/lib/deb/s3/lock.rb
+++ b/lib/deb/s3/lock.rb
@@ -30,7 +30,8 @@ class Deb::S3::Lock
     def lock(codename, component = nil, architecture = nil, cache_control = nil)
       lockfile = Tempfile.new("lockfile")
 
-      lockfile_content = "#{Etc.getlogin}@#{Socket.gethostname}_#{SecureRandom.hex}"
+      # Write lock using a random number to ensure collisions dont occur from the same machine
+      lockfile_content = "#{Etc.getlogin}@#{Socket.gethostname}\n#{SecureRandom.hex}"
       lockfile.write lockfile_content
       lockfile.close
 
@@ -49,7 +50,7 @@ class Deb::S3::Lock
 
     def current(codename, component = nil, architecture = nil, cache_control = nil)
       lock_content = Deb::S3::Utils.s3_read(lock_path(codename, component, architecture, cache_control))
-      lock_content = lock_content.split('_').first.split('@')
+      lock_content = lock_content.split.first.split('@')
       lock = Deb::S3::Lock.new
       lock.user = lock_content[0]
       lock.host = lock_content[1] if lock_content.size > 1

--- a/lib/deb/s3/lock.rb
+++ b/lib/deb/s3/lock.rb
@@ -15,7 +15,6 @@ class Deb::S3::Lock
 
   class << self
     def locked?(codename, component = nil, architecture = nil, cache_control = nil)
-      puts lock_path(codename, component, architecture, cache_control)
       Deb::S3::Utils.s3_exists?(lock_path(codename, component, architecture, cache_control))
     end
 


### PR DESCRIPTION
There was an issue where two deb-s3 processes could write a lock file and continue to upload losing one the packages they were kicked off in the same time frame. This was relatively common when running concurrent CI builds.

To solve this I added a read check once a package is written so that it checks if it successfully holds the lock, using a random string to avoid instances where this happens on the same host.