### PR TITLE
Add option for custom gpg command

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -96,6 +96,11 @@ class Deb::S3::CLI < Thor
   :type    => :string,
   :desc    => "Additional command line options to pass to GPG when signing."
 
+  class_option :gpg_cmd,
+  :default => "",
+  :type    => :string,
+  :desc    => "Arbitrary gpg command to run for signing."
+
   class_option :encryption,
   :default  => false,
   :type     => :boolean,
@@ -597,6 +602,7 @@ class Deb::S3::CLI < Thor
     Deb::S3::Utils.bucket      = options[:bucket]
     Deb::S3::Utils.signing_key = options[:sign]
     Deb::S3::Utils.gpg_options = options[:gpg_options]
+    Deb::S3::Utils.gpg_cmd     = options[:gpg_cmd]
     Deb::S3::Utils.prefix      = options[:prefix]
     Deb::S3::Utils.encryption  = options[:encryption]
 

--- a/lib/deb/s3/release.rb
+++ b/lib/deb/s3/release.rb
@@ -102,9 +102,11 @@ class Deb::S3::Release
 
     # sign the file, if necessary
     if Deb::S3::Utils.signing_key
+      local_file = release_tmp.path+".asc"
       key_param = Deb::S3::Utils.signing_key != "" ? "--default-key=#{Deb::S3::Utils.signing_key}" : ""
-      if system("gpg -a #{key_param} --digest-algo SHA256 #{Deb::S3::Utils.gpg_options} -s --clearsign #{release_tmp.path}")
-        local_file = release_tmp.path+".asc"
+      gpg_cmd = Deb::S3::Utils.gpg_cmd != "" ? Deb::S3::Utils.gpg_cmd : "gpg" 
+    
+      if system("#{gpg_cmd} -a #{key_param} --digest-algo SHA256 #{Deb::S3::Utils.gpg_options} -s --clearsign #{release_tmp.path}")
         remote_file = "dists/#{@codename}/InRelease"
         yield remote_file if block_given?
         raise "Unable to locate InRelease file" unless File.exists?(local_file)
@@ -113,8 +115,8 @@ class Deb::S3::Release
       else
         raise "Signing the InRelease file failed."
       end
-      if system("gpg -a #{key_param} --digest-algo SHA256 #{Deb::S3::Utils.gpg_options} -b #{release_tmp.path}")
-        local_file = release_tmp.path+".asc"
+
+      if system("#{gpg_cmd} -a #{key_param} --digest-algo SHA256 #{Deb::S3::Utils.gpg_options} -b #{release_tmp.path}")
         remote_file = self.filename+".gpg"
         yield remote_file if block_given?
         raise "Unable to locate Release signature file" unless File.exists?(local_file)

--- a/lib/deb/s3/utils.rb
+++ b/lib/deb/s3/utils.rb
@@ -16,6 +16,8 @@ module Deb::S3::Utils
   def signing_key= v; @signing_key = v end
   def gpg_options; @gpg_options end
   def gpg_options= v; @gpg_options = v end
+  def gpg_cmd; @gpg_cmd end
+  def gpg_cmd= v; @gpg_cmd = v end
   def prefix; @prefix end
   def prefix= v; @prefix = v end
   def encryption; @encryption end


### PR DESCRIPTION
Folks, for your consideration here's a minor change to allow commands other than "gpg" to be passed in as cli option. This is useful when a machine running this script has `gpg2` instead of plain `gpg` or perhaps other gpg-compliant tooling that's not `gpg` or wraps it.

This is a backwards-compatible change and does not interfere or breaks cli functionality as it exists today.

Example of cli option being used: 
`deb-s3 upload --bucket my-bucket my-deb-package-1.0.0_amd64.deb --gpg_cmd gpg2` 

Signed-off-by: Ruben Orduz <rubenoz@gmail.com>