### PR TITLE
Use ar to determine the control file's actual name

### DIFF
--- a/lib/deb/s3/package.rb
+++ b/lib/deb/s3/package.rb
@@ -59,16 +59,22 @@ class Deb::S3::Package
       if system("which dpkg > /dev/null 2>&1")
         `dpkg -f #{package}`
       else
+        # use ar to determine control file name (control.ext)
+        package_files = `ar t #{package}`
+        control_file = package_files.split("\n").select do |file|
+          file.start_with?("control.")
+        end.first
+
         # ar fails to find the control.tar.gz tarball within the .deb
         # on Mac OS. Try using ar to list the control file, if found,
         # use ar to extract, otherwise attempt with tar which works on OS X.
-        extract_control_tarball_cmd = "ar p #{package} control.tar.gz"
+        extract_control_tarball_cmd = "ar p #{package} #{control_file}"
 
         begin
-          safesystem("ar t #{package} control.tar.gz &> /dev/null")
+          safesystem("ar t #{package} #{control_file} &> /dev/null")
         rescue SafeSystemError
           warn "Failed to find control data in .deb with ar, trying tar."
-          extract_control_tarball_cmd = "tar zxf #{package} --to-stdout control.tar.gz"
+          extract_control_tarball_cmd = "tar zxf #{package} --to-stdout #{control_file}"
         end
 
         Dir.mktmpdir do |path|


### PR DESCRIPTION
Not all deb packages use gzip for compressing their files, and gzip is
no longer the default (Debian's documentation says xz is used by default
now), because of this Deb::S3::Packages#extract_control fails on newly
built deb packages.

This change uses ar to determine the actual control file name before
attempting to do operations on it.

Confirmed that this worked

```
# old output
>> Retrieving existing manifests
>> Examining package file bash-static_4.4.18-2ubuntu1journera1_amd64.deb
Failed to find control data in .deb with ar, trying tar.
tar: control.tar.gz: Not found in archive
tar: Error exit delayed from previous errors.
Traceback (most recent call last):
        14: from /usr/local/bin/deb-s3:23:in `<main>'
        13: from /usr/local/bin/deb-s3:23:in `load'
        12: from /usr/local/lib/ruby/gems/2.5.0/gems/deb-s3-0.10.0/bin/deb-s3:9:in `<top (required)>'
        11: from /usr/local/lib/ruby/gems/2.5.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
        10: from /usr/local/lib/ruby/gems/2.5.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
         9: from /usr/local/lib/ruby/gems/2.5.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
         8: from /usr/local/lib/ruby/gems/2.5.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
         7: from /usr/local/lib/ruby/gems/2.5.0/gems/deb-s3-0.10.0/lib/deb/s3/cli.rb:188:in `upload'
         6: from /usr/local/lib/ruby/gems/2.5.0/gems/deb-s3-0.10.0/lib/deb/s3/cli.rb:188:in `each'
         5: from /usr/local/lib/ruby/gems/2.5.0/gems/deb-s3-0.10.0/lib/deb/s3/cli.rb:190:in `block in upload'
         4: from /usr/local/lib/ruby/gems/2.5.0/gems/deb-s3-0.10.0/lib/deb/s3/package.rb:46:in `parse_file'
         3: from /usr/local/lib/ruby/gems/2.5.0/gems/deb-s3-0.10.0/lib/deb/s3/package.rb:74:in `extract_control'
         2: from /usr/local/Cellar/ruby/2.5.1/lib/ruby/2.5.0/tmpdir.rb:89:in `mktmpdir'
         1: from /usr/local/lib/ruby/gems/2.5.0/gems/deb-s3-0.10.0/lib/deb/s3/package.rb:76:in `block in extract_control'
/usr/local/lib/ruby/gems/2.5.0/gems/deb-s3-0.10.0/lib/deb/s3/package.rb:76:in `read': No such file or directory @ rb_sysopen - /var/folders/17/77jz89_9663076r0nlw91ny80000gn/T/d20180924-81675-fahdb1/control (Errno::ENOENT)

# new output
>> Retrieving existing manifests
>> Examining package file bash-builtins_4.4.18-2ubuntu1journera1_amd64.deb
>> Examining package file bash-doc_4.4.18-2ubuntu1journera1_all.deb
>> Examining package file bash-static_4.4.18-2ubuntu1journera1_amd64.deb
>> Examining package file bash_4.4.18-2ubuntu1journera1_amd64.deb
>> Uploading packages and new manifests to S3
```