### PR TITLE
Store Release after Release.gpg

### DIFF
--- a/lib/deb/s3/release.rb
+++ b/lib/deb/s3/release.rb
@@ -98,7 +98,6 @@ class Deb::S3::Release
     release_tmp.puts self.generate
     release_tmp.close
     yield self.filename if block_given?
-    s3_store(release_tmp.path, self.filename, 'text/plain; charset=utf-8', self.cache_control)
 
     # sign the file, if necessary
     if Deb::S3::Utils.signing_key
@@ -128,6 +127,7 @@ class Deb::S3::Release
       s3_remove(self.filename+".gpg")
     end
 
+    s3_store(release_tmp.path, self.filename, 'text/plain; charset=utf-8', self.cache_control)
     release_tmp.unlink
   end
 


### PR DESCRIPTION
I work for a fairly large company and we're storing our Debian repository in S3, using `deb-s3` for uploads. There have been quite a few occasions the whole repository broke (causing widespread failure on scale-out) due to botched uploads.

Currently, `deb-s3` uploads `Release` and only then `Release.gpg`. If, for example, the GPG key ID is wrong or the key doesn't exist, running `deb-s3` will break production, since the signature won't match.

I haven't been able to test this PR yet, but was wondering what you'd think of something similar? Generating `Release.gpg` seems more prone to failure, so dealing with it first would allow failing early.

Thanks for the great project!